### PR TITLE
Migrate user agent util to model runtime

### DIFF
--- a/ask-sdk-model-runtime/pom.xml
+++ b/ask-sdk-model-runtime/pom.xml
@@ -48,6 +48,11 @@
             <version>2.9.10</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.8.2</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/ask-sdk-model-runtime/src/com/amazon/ask/model/services/util/UserAgentHelper.java
+++ b/ask-sdk-model-runtime/src/com/amazon/ask/model/services/util/UserAgentHelper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.model.services.util;
+
+import org.slf4j.Logger;
+
+import java.util.Properties;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class UserAgentHelper {
+
+    private static Logger logger = getLogger(UserAgentHelper.class);
+
+    private final String sdkVersion;
+    private final String customUserAgent;
+
+    protected UserAgentHelper(String sdkVersion, String customUserAgent) {
+        this.sdkVersion = sdkVersion;
+        this.customUserAgent = customUserAgent;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the user agent string.  Format is "(SDK name)/(SDK version) (Language)/(Language version)"
+     * Custom user agent will be appended to the end of the standard user agent.
+     *
+     * @return user agent string
+     */
+    public String getUserAgent() {
+        Properties systemProperties;
+        try {
+            systemProperties = System.getProperties();
+        } catch (SecurityException e) {
+            logger.debug("Unable to determine JVM version due to security restrictions.");
+            systemProperties = null;
+        }
+        return internalGetUserAgent(systemProperties, customUserAgent);
+    }
+
+    String internalGetUserAgent(Properties systemProperties, String customUserAgent) {
+        String version = sdkVersion != null ? sdkVersion : "UNKNOWN";
+        String coreUserAgent = String.format("ask-java/%s Java/%s", version, getJavaVersion(systemProperties));
+        return coreUserAgent + (customUserAgent != null ? " " + customUserAgent : "");
+    }
+
+    private static String getJavaVersion(Properties systemProperties) {
+        if (systemProperties != null && systemProperties.getProperty("java.version") != null) {
+            return systemProperties.getProperty("java.version");
+        }
+        return "UNKNOWN";
+    }
+
+    public static final class Builder {
+        private String sdkVersion;
+        private String customUserAgent;
+
+        // prevent instantiation
+        private Builder() {}
+
+        public Builder withSdkVersion(String sdkVersion) {
+            this.sdkVersion = sdkVersion;
+            return this;
+        }
+
+        public Builder withCustomUserAgent(String customUserAgent) {
+            this.customUserAgent = customUserAgent;
+            return this;
+        }
+
+        public UserAgentHelper build() {
+            return new UserAgentHelper(sdkVersion, customUserAgent);
+        }
+    }
+
+}

--- a/ask-sdk-model-runtime/tst/com/amazon/ask/model/services/util/UserAgentHelperTest.java
+++ b/ask-sdk-model-runtime/tst/com/amazon/ask/model/services/util/UserAgentHelperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.model.services.util;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserAgentHelperTest {
+
+    private static String TEST_JVM_VERSION = "1.8.0_151";
+    private static String TEST_SDK_VERSION = "2.0.0";
+
+    @Test
+    public void userAgentGeneratedWithExpectedSdkAndJvmVersion() {
+        UserAgentHelper helper = UserAgentHelper.builder().withSdkVersion(TEST_SDK_VERSION).build();
+        Properties props = mock(Properties.class);
+        when(props.getProperty("java.version")).thenReturn(TEST_JVM_VERSION);
+        assertEquals(helper.internalGetUserAgent(props, null), String.format("ask-java/%s Java/%s", TEST_SDK_VERSION, TEST_JVM_VERSION));
+    }
+
+    @Test
+    public void customUserAgentAppendedToEnd() {
+        String customUserAgent = "foo/bar/baz";
+        UserAgentHelper helper = UserAgentHelper.builder().withSdkVersion(TEST_SDK_VERSION).withCustomUserAgent(customUserAgent).build();
+        Properties props = mock(Properties.class);
+        when(props.getProperty("java.version")).thenReturn(TEST_JVM_VERSION);
+        assertEquals(helper.internalGetUserAgent(props, customUserAgent), String.format("ask-java/%s Java/%s foo/bar/baz", TEST_SDK_VERSION, TEST_JVM_VERSION));
+    }
+
+    @Test
+    public void nullJvmPropertiesReturnsUnknownJvmVersion() {
+        UserAgentHelper helper = UserAgentHelper.builder().withSdkVersion(TEST_SDK_VERSION).build();
+        assertEquals(helper.internalGetUserAgent(null, null), String.format("ask-java/%s Java/UNKNOWN", TEST_SDK_VERSION));
+    }
+
+    @Test
+    public void unsetSdkVersionReturnsUnknownSdkVersion() {
+        UserAgentHelper helper = UserAgentHelper.builder().build();
+        Properties props = mock(Properties.class);
+        when(props.getProperty("java.version")).thenReturn(TEST_JVM_VERSION);
+        assertEquals(helper.internalGetUserAgent(props, null), String.format("ask-java/UNKNOWN Java/%s", TEST_JVM_VERSION));
+    }
+
+}


### PR DESCRIPTION
## Description
Migrates the user agent utility to the model runtime so it can be consumed by service clients. Specific library versions are injected by the consumer.

## Testing
New unit tests.

## Motivation and Context
Change to allow service clients such as the SMAPI client to attach basic SDK version information to a user agent header.

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] The change is generic and can be done across all model classes.
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
