### PR TITLE
Bump jackson-databind to 2.10.5.1 to address CVE-2020-25649

### DIFF
--- a/ask-sdk-model-runtime/pom.xml
+++ b/ask-sdk-model-runtime/pom.xml
@@ -35,17 +35,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.4</version>
+            <version>2.10.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.4</version>
+            <version>2.10.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.4</version>
+            <version>2.10.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Description
Bump jackson-databind to 2.10.5.1 to address CVE-2020-25649

## Checklist
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [x] The change is generic and can be done across all model classes.
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
